### PR TITLE
[Chore] add docker for dev

### DIFF
--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,6 @@
+node_modules
+Dockerfile
+.git
+.gitignore
+.dockerignore
+.env

--- a/frontend/Dockerfile.dev
+++ b/frontend/Dockerfile.dev
@@ -1,0 +1,7 @@
+FROM node:18.15.0
+WORKDIR /app
+COPY package.json .
+RUN npm install
+COPY . .
+EXPOSE 3000
+CMD ["npm", "run" ,"dev"]

--- a/frontend/dev.sh
+++ b/frontend/dev.sh
@@ -1,0 +1,1 @@
+docker-compose -f docker-compose.yml -f docker-compose-dev.yml up -d --build

--- a/frontend/docker-compose-dev.yml
+++ b/frontend/docker-compose-dev.yml
@@ -1,0 +1,10 @@
+version: '3'
+services:
+  react-app:
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+    ports:
+      - '3000:3000'
+    volumes:
+      - ./src:/app/src

--- a/frontend/docker-compose.yml
+++ b/frontend/docker-compose.yml
@@ -1,0 +1,7 @@
+version: '3'
+services:
+  react-app:
+    build:
+      context: .
+    ports:
+      - '3000:3000'

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,8 +1,12 @@
-import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react-swc';
+import { defineConfig } from 'vite';
 import tsconfigPaths from 'vite-tsconfig-paths';
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react(), tsconfigPaths()],
+  server: {
+    host: true,
+    port: 3000,
+  },
 });


### PR DESCRIPTION
- vite는 서버를 열 때 'npm run dev'를 사용
- vite port 번호는 3000번으로 일치
- docker 파일로 container를 띄우려면 frontend 파일에서 sh dev.sh 엔터 누르면 도커 컨테이너 실행가능
- 이후 브라우저에서 localhost:3000으로 접속하면 개발환경 제공됨.